### PR TITLE
Fix an JavaScript syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The result parsing the PGN above would be
         result: "*",
         moves: [
             { move: 'e4', move_number: 1},
-            { move: 'e5',
+            { move: 'e5'},
             { move: 'Nf3', move_number: 2},
             { move: 'Nc6'},
             { move: 'Bc4', move_number: 3},


### PR DESCRIPTION
I think that an javascript object in README.md has a SyntaxError.