### PR TITLE
Update result for when curly braces are present

### DIFF
--- a/src/grammar.peg
+++ b/src/grammar.peg
@@ -78,7 +78,7 @@ check = "+"
 checkmate = "#"
 capture = "x"
 period = "."
-result = "1-0" / "0-1" / "*" / "1/2-1/2"
+result = "1-0" / "0-1" / "*" / "1/2-1/2" / "{0-1}" / "{1-0}" / "{1/2-1/2}"
 move_number = mn:integer period? (period period)? {return mn}
 square = r:rank f:file {return r+f}
 promotion = "="? [QRBN]


### PR DESCRIPTION
Hey, I recently copied my PGN from chess.com to be analyzed on @WintrCat's [Freechess](https://chess.wintrcat.uk/) but the PGN kept failing parsing, upon further investigation, I found that the result in the .peg file did not handle the curly braces case, hopefully this would resolve that. 

Here's the PGN for the said game.

```
[Event "Computer Game"]
[Site "Chess.com iPhone"]
[Date "2024.05.11"]
[Round "?"]
[White "umairjibran"]
[Black "Ezra (Gen A)"]
[Result "0-1"]
[FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"]
[BlackElo "2150"]
[Termination "Ezra (Gen A) wins by Checkmate"]

1.e4 c5 2.d4 cxd4 3.Qxd4 Nc6 4.Qd1 e6 5.Nf3 d5 6.exd5 exd5 7.Bg5 Be7 8.Bxe7 Ngxe7
9.Bb5 O-O 10.O-O Bf5 11.Nc3 h6 12.Bxc6 bxc6 13.h3 c5 14.g4 Bg6 15.Ne5 Rb8 16.Nxg6 fxg6
17.Qd2 Qd6 18.Rad1 d4 19.b3 Qc6 20.g5 Qf3 21.gxh6 Rf5 22.Na4 Rh5 23.Rde1 Qxh3
24.f3 Qh1+ 25.Kf2 Qh2#  {0-1}
```